### PR TITLE
Fix sitrep url

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -87,7 +87,7 @@
 
   {
     "package": "sitrep",
-    "url": "https://r4epi.github.io/sitrep/"
+    "url": "https://github.com/R4EPI/sitrep"
   },
 
   // REACH IMpac suite...


### PR DESCRIPTION
The URL must be a git repository.

cc @Edouard-Legoupil
